### PR TITLE
Update deps for Dome: use msgs6

### DIFF
--- a/.github/workflows/ci-bionic.yml
+++ b/.github/workflows/ci-bionic.yml
@@ -13,5 +13,5 @@ jobs:
         id: ci
         uses: ignition-tooling/ubuntu-bionic-ci-action@master
         with:
-          apt-dependencies: 'pkg-config libprotobuf-dev protobuf-compiler libprotoc-dev libzmq3-dev uuid-dev libsqlite3-dev libignition-cmake2-dev libignition-math6-dev libignition-msgs5-dev libignition-tools-dev'
+          apt-dependencies: 'pkg-config libprotobuf-dev protobuf-compiler libprotoc-dev libzmq3-dev uuid-dev libsqlite3-dev libignition-cmake2-dev libignition-math6-dev libignition-msgs6-dev libignition-tools-dev'
           codecov-token: ${{ secrets.CODECOV_TOKEN }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,8 +62,8 @@ endif()
 
 #--------------------------------------
 # Find ignition-msgs
-ign_find_package(ignition-msgs5 REQUIRED)
-set(IGN_MSGS_VER ${ignition-msgs5_VERSION_MAJOR})
+ign_find_package(ignition-msgs6 REQUIRED)
+set(IGN_MSGS_VER ${ignition-msgs6_VERSION_MAJOR})
 
 #--------------------------------------
 # Find ifaddrs

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,9 @@
 
 ### Ignition Transport 9.X.X
 
+1. Need ignition-msgs version 6
+   * [Github pull request 149](https://github.com/ignitionrobotics/ign-transport/pull/149/files)
+
 ### Ignition Transport 9.0.0
 
 ## Ignition Transport 8.X

--- a/configure.bat
+++ b/configure.bat
@@ -6,7 +6,7 @@
 :: Install dependencies
 call %win_lib% :download_unzip_install libzmq-4.2.3_cppzmq-4.2.2_vc15-x64-dll-MD.zip
 call %win_lib% :download_unzip_install sqlite-3.22.0-vc15-Win64-dll-MD.zip
-call %win_lib% :install_ign_project ign-msgs ign-msgs5
+call %win_lib% :install_ign_project ign-msgs ign-msgs6
 
 :: Set configuration variables
 @set build_type=Release

--- a/configure.bat
+++ b/configure.bat
@@ -6,7 +6,7 @@
 :: Install dependencies
 call %win_lib% :download_unzip_install libzmq-4.2.3_cppzmq-4.2.2_vc15-x64-dll-MD.zip
 call %win_lib% :download_unzip_install sqlite-3.22.0-vc15-Win64-dll-MD.zip
-call %win_lib% :install_ign_project ign-msgs ign-msgs6
+call %win_lib% :install_ign_project ign-msgs master
 
 :: Set configuration variables
 @set build_type=Release

--- a/docker/ign-transport/Dockerfile
+++ b/docker/ign-transport/Dockerfile
@@ -72,7 +72,7 @@ RUN sudo /bin/sh -c 'echo "deb [trusted=yes] http://packages.osrfoundation.org/g
  && sudo apt-get install -y \
     libignition-cmake2-dev \
     libignition-math6-dev \
-    libignition-msgs5-dev \
+    libignition-msgs6-dev \
  && sudo apt-get clean
 
 # Ignition transport


### PR DESCRIPTION
As part of the works of https://github.com/ignition-tooling/gazebodistro/pull/5 bump the use of msgs to major version 6