### PR TITLE
Removed repeated installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ combination of custom code and ZeroMQ.
 
 # Install
 
-Review the [tutorial section](tutorials/02_installation.md).
+Review the [tutorial section](https://ignitionrobotics.org/api/transport/9.0/installation.html).
 
 # Usage
 

--- a/README.md
+++ b/README.md
@@ -59,28 +59,7 @@ combination of custom code and ZeroMQ.
 
 # Install
 
-We recommend following the [Binary Install](#markdown-header-binary-install)
-instructions to get up and running as quickly and painlessly as possible.
-
-The [Source Install](#markdown-header-source-install) instructions should be
-used if you need the very latest software improvements, you need to modify the
-code, or you plan to make a contribution.
-
-## Binary Install
-
-On Ubuntu systems, `apt-get` can be used to install `ignition-transport`:
-
-```
-$ sudo apt install libignition-transport<#>-dev
-```
-
-Be sure to replace `<#>` with a number value, such as `1` or `2`, depending on
-which version you need.
-
-## Source Install
-
-See the [install](https://ignitionrobotics.org/api/transport/8.0/installation.html)
-section of the documentation.
+Review the [tutorial section](tutorials/02_installation.md).
 
 # Usage
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ combination of custom code and ZeroMQ.
 
 # Install
 
-Review the [tutorial section](https://ignitionrobotics.org/api/transport/9.0/installation.html).
+See the [installation tutorial](https://ignitionrobotics.org/api/transport/9.0/installation.html).
 
 # Usage
 

--- a/tutorials/02_installation.md
+++ b/tutorials/02_installation.md
@@ -25,12 +25,14 @@ Setup keys:
 wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
 ```
 
-Install Ignition Transport:
+Install Ignition Transport, `apt-get` can be used to install `ignition-transport`:
 
 ```
-sudo apt-get update
-sudo apt-get install libignition-transport9-dev
+$ sudo apt install libignition-transport<#>-dev
 ```
+
+Be sure to replace `<#>` with a number value, such as `1` or `2`, depending on
+which version you need.
 
 ## Mac OS X
 


### PR DESCRIPTION
This PR is related with this issue https://github.com/ignitionrobotics/docs/issues/14

Moved install instructions to the tutorials folder.

Signed-off-by: ahcorde <ahcorde@gmail.com>