### PR TITLE
Prevent empty messages from spamming the console.

### DIFF
--- a/log/src/Recorder.cc
+++ b/log/src/Recorder.cc
@@ -424,7 +424,8 @@ void Recorder::Implementation::WriteToLogFile(const LogData &_logData)
         reinterpret_cast<const void *>(_logData.msgData.data()),
         _logData.msgData.size()))
   {
-    LWRN("Failed to insert message into log file\n");
+    LWRN("Failed to insert message into log file from topic["
+        << _logData.msgInfo.Topic() << "]\n");
   }
   // TODO(anyone) It would be nice for testing to simulate long delays
   // associated with disk writes. In the mean time, a sleep can be added here


### PR DESCRIPTION
A topic could publish an Int32 or Int64 message with data=0. In this situation the protobuf message has size zero. While this is not a problem for protobuf messages, it is considered an error for SQLite3. 

Added logic to prevent console spamming.

Signed-off-by: Nate Koenig <nate@openrobotics.org>