### PR TITLE
Fix mem leak

### DIFF
--- a/src/NodeShared.cc
+++ b/src/NodeShared.cc
@@ -1636,6 +1636,8 @@ void NodeSharedPrivate::AccessControlHandler()
     {
       std::cerr << "Username and password not set. "
                 << "Authentication is disabled\n";
+      sock->close();
+      delete sock;
       return;
     }
 

--- a/src/NodeShared.cc
+++ b/src/NodeShared.cc
@@ -1761,6 +1761,7 @@ void NodeSharedPrivate::AccessControlHandler()
   }
 
   sock->close();
+  delete sock;
 }
 
 /////////////////////////////////////////////////


### PR DESCRIPTION
Fixing a small memory leak that I came across while profiling ign-gazebo.  Not sure if `sock` needs to be closed before that `return` call though, but since it was being done at the end of the function, I added it before the error-out `return` call as well.