### PR TITLE
Add macOS 10.15 workflow, test <filesystem> support

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,37 @@
+name: macOS latest
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    env:
+      PACKAGE: ignition-transport9
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Homebrew
+      id: set-up-homebrew
+      uses: Homebrew/actions/setup-homebrew@master
+    - run: brew config
+
+    - name: Install base dependencies
+      run: |
+        brew tap osrf/simulation;
+        brew install --only-dependencies ${PACKAGE};
+
+    - run: mkdir build
+    - name: cmake
+      working-directory: build
+      run: cmake .. -DCMAKE_INSTALL_PREFIX=/usr/local/Cellar/${PACKAGE}/HEAD
+    - run: make
+      working-directory: build
+    - run: make test
+      working-directory: build
+      env:
+        CTEST_OUTPUT_ON_FAILURE: 1
+    - name: make install
+      working-directory: build
+      run: |
+        make install;
+        brew link ${PACKAGE};

--- a/test/integration/authPubSubSubscriberInvalid_aux.cc
+++ b/test/integration/authPubSubSubscriberInvalid_aux.cc
@@ -18,9 +18,6 @@
 #include <chrono>
 #include <string>
 #include <ignition/msgs.hh>
-#ifdef _WIN32
-  #include <filesystem>
-#endif
 
 #include "ignition/transport/Node.hh"
 #include "gtest/gtest.h"

--- a/test/integration/twoProcsPubSubSubscriber_aux.cc
+++ b/test/integration/twoProcsPubSubSubscriber_aux.cc
@@ -18,9 +18,6 @@
 #include <chrono>
 #include <string>
 #include <ignition/msgs.hh>
-#ifdef _WIN32
-  #include <filesystem>
-#endif
 
 #include "ignition/transport/Node.hh"
 #include "gtest/gtest.h"

--- a/test/test_config.h.in
+++ b/test/test_config.h.in
@@ -30,12 +30,10 @@
   DETAIL_IGN_TRANSPORT_TEST_DIR
 #endif
 
-#ifndef __APPLE__
-  #if __unix__ && __GNUC__ < 8
-    #include <experimental/filesystem>
-  #else
-    #include <filesystem>
-  #endif
+#if __unix__ && __GNUC__ < 8
+  #include <experimental/filesystem>
+#else
+  #include <filesystem>
 #endif
 
 #include <climits>
@@ -94,17 +92,12 @@ namespace testing
   std::string portablePathUnion(const std::string &_str1,
                                 const std::string &_str2)
   {
-#ifdef __APPLE__
-    // Ugly as hell but trying to avoid boost::filesystem
-    return _str1 + "/" + _str2;
-#else
     #if __unix__ && __GNUC__ < 8
       using namespace std::experimental::filesystem;
     #else
       using namespace std::filesystem;
     #endif
     return (path(_str1) / path(_str2)).string();
-#endif
   }
 
 #ifdef _WIN32


### PR DESCRIPTION
This adds a macOS 10.15 workflow in order to test support for c++ filesystem on 10.15. I expect it to pass on 10.15 and fail on our jenkins 10.14 builds. Marked as a draft as this is primarily a test to illustrate support on different OS versions.

cc @mjcarroll 