### PR TITLE
⬆️  7.5.1 🏁

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(ignition-transport7 VERSION 7.5.0)
+project(ignition-transport7 VERSION 7.5.1)
 
 #============================================================================
 # Find ignition-cmake

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,16 @@
 ## Ignition Transport 7
 
-### Ignition Transport 7.x.x (202x-xx-xx)
+### Ignition Transport 7.5.1 (2020-12-23)
+
+1. CI fixes
+    * [Pull request 158](https://github.com/ignitionrobotics/ign-transport/pull/158)
+    * [Pull request 176](https://github.com/ignitionrobotics/ign-transport/pull/176)
+
+1. Fix codecheck
+    * [Pull request 194](https://github.com/ignitionrobotics/ign-transport/pull/194)
+
+1. Prevent empty messages from spamming the console
+    * [Pull request 164](https://github.com/ignitionrobotics/ign-transport/pull/164)
 
 ### Ignition Transport 7.5.0 (2020-07-29)
 


### PR DESCRIPTION
Preparing for a last major version 7 release before Blueprint EOLs in 8 days.

Comparison to 7.5.0:

https://github.com/ignitionrobotics/ign-transport/compare/ignition-transport7_7.5.0...ign-transport7

There are no PRs open against `ign-transport7`.