### PR TITLE
Depend on cli component of ignition-utils

### DIFF
--- a/.github/ci/packages.apt
+++ b/.github/ci/packages.apt
@@ -2,6 +2,7 @@ libignition-cmake2-dev
 libignition-math6-dev
 libignition-msgs7-dev
 libignition-tools-dev
+libignition-utils1-cli-dev
 libprotobuf-dev
 libprotoc-dev
 libsqlite3-dev

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,11 @@ else()
 endif()
 
 #--------------------------------------
+# Find ignition-utils
+ign_find_package(ignition-utils1 REQUIRED COMPONENTS cli)
+set(IGN_UTILS_VER ${ignition-utils1_VERSION_MAJOR})
+
+#--------------------------------------
 # Find ignition-msgs
 ign_find_package(ignition-msgs7 REQUIRED)
 set(IGN_MSGS_VER ${ignition-msgs7_VERSION_MAJOR})

--- a/Migration.md
+++ b/Migration.md
@@ -6,6 +6,13 @@ Deprecated code produces compile-time warnings. These warning serve as
 notification to users that their code should be upgraded. The next major
 release will remove the deprecated code.
 
+## Ignition Transport 9.X to 10.X
+
+### Addition
+
+1. Dependency on `cli` component of `ignition-utils`.
+    * [GitHub pull request 229](https://github.com/ignitionrobotics/ign-transport/pull/229)
+
 ## Ignition Transport 8.X to 9.X
 
 ### Removed

--- a/docker/ign-transport/Dockerfile
+++ b/docker/ign-transport/Dockerfile
@@ -73,6 +73,7 @@ RUN sudo /bin/sh -c 'echo "deb [trusted=yes] http://packages.osrfoundation.org/g
     libignition-cmake2-dev \
     libignition-math6-dev \
     libignition-msgs7-dev \
+    libignition-utils1-cli-dev \
  && sudo apt-get clean
 
 # Ignition transport

--- a/tutorials/02_installation.md
+++ b/tutorials/02_installation.md
@@ -94,7 +94,7 @@ sudo apt-get remove libignition-transport.*-dev
 
 Install prerequisites. A clean Ubuntu system will need:
 ```
-sudo apt-get install git cmake pkg-config python ruby-ronn libprotoc-dev libprotobuf-dev protobuf-compiler uuid-dev libzmq3-dev libignition-msgs-dev
+sudo apt-get install git cmake pkg-config python ruby-ronn libprotoc-dev libprotobuf-dev protobuf-compiler uuid-dev libzmq3-dev libignition-msgs-dev libignition-utils1-cli-dev
 ```
 
 Clone the repository


### PR DESCRIPTION
# 🎉 New feature

This is the new dependency part of #216

## Summary

Add a dependency on the `cli` component of ignition-utils. This will be used to refactor the `ign` tool commands.

## Test it

It should pass CI.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [X] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
