### PR TITLE
🎈 10.0.0~pre1

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,27 @@
+## Ignition Transport 10.X
+
+### Ignition Transport 10.X.X
+
+### Ignition Transport 10.0.0 (2021-XX-XX)
+
+1. Depend on cli component of ignition-utils
+    * [Pull request #229](https://github.com/ignitionrobotics/ign-transport/pull/229)
+
+1. Add instructions to build and run examples
+    * [Pull request #222](https://github.com/ignitionrobotics/ign-transport/pull/222)
+
+1. Bump in edifice: ign-msgs7
+    * [Pull request #213](https://github.com/ignitionrobotics/ign-transport/pull/213)
+
+1. Configurable IP address and port for discovery
+    * [Pull request #200](https://github.com/ignitionrobotics/ign-transport/pull/200)
+
+1. Changes from Dome tutorial party
+    * [Pull request #187](https://github.com/ignitionrobotics/ign-transport/pull/187)
+
+1. Infrastructure
+    * [Pull request #186](https://github.com/ignitionrobotics/ign-transport/pull/186)
+
 ## Ignition Transport 9.X
 
 ### Ignition Transport 9.X.X


### PR DESCRIPTION
# 🎈 Release

Preparation for 10.0.0~pre1 release.

Comparison to version 9: https://github.com/ignitionrobotics/ign-transport/compare/ign-transport9...main

The version in `CMakeLists` is already up-to-date.

## Checklist
- [x] Asked team if this is a good time for a release
- [x] There are no changes to be ported from the previous major version
- [x] No PRs targeted at this major version are close to getting in
- [x] Bumped minor for new features, patch for bug fixes
- [x] Updated changelog
- [x] Updated migration guide (as needed)
- [x] Link to PR updating dependency versions in appropriate repository in [ignition-release](https://github.com/ignition-release) (as needed): <LINK>

<!-- Please refer to http://github.com/docs/release.md#triggering-a-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge**
