### PR TITLE
 Make zmq check for post 4.3.1 not to include 4.3.1

### DIFF
--- a/include/ignition/transport/Helpers.hh
+++ b/include/ignition/transport/Helpers.hh
@@ -31,7 +31,7 @@
 #include "ignition/transport/Export.hh"
 
 // Avoid using deprecated message send/receive function when possible.
-#if ZMQ_VERSION >= ZMQ_MAKE_VERSION(4, 3, 1)
+#if ZMQ_VERSION > ZMQ_MAKE_VERSION(4, 3, 1)
   #define IGN_ZMQ_POST_4_3_1
 #endif
 


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

When building Debian packages for Debian/Buster I needed to use this patch to fix compilation. Seems like we were including the `4.3.1` to define the `IGN_ZMQ_POST_4_3_1` variable, which clearly seems to be a mistake.

## Checklist
- [x] Signed all commits for DCO

**Note to maintainers**: Remember to use **Squash-Merge**
