### PR TITLE
Remove unnecessary copy and assignment operators

### DIFF
--- a/include/ignition/transport/Publisher.hh
+++ b/include/ignition/transport/Publisher.hh
@@ -58,10 +58,6 @@ namespace ignition
                         const std::string &_nUuid,
                         const AdvertiseOptions &_opts);
 
-      /// \brief Copy constructor.
-      /// \param[in] _other Other Publisher object.
-      public: Publisher(const Publisher &_other);
-
       /// \brief Destructor.
       public: virtual ~Publisher() = default;
 
@@ -137,11 +133,6 @@ namespace ignition
       /// \return True if this object does not match the provided object.
       public: bool operator!=(const Publisher &_pub) const;
 
-      /// \brief Assignment operator.
-      /// \param[in] _other The other Publisher.
-      /// \return A reference to this instance.
-      public: Publisher &operator=(const Publisher &_other);
-
       /// \brief Stream insertion operator.
       /// \param[out] _out The output stream.
       /// \param[in] _msg Publisher to write to the stream.
@@ -207,10 +198,6 @@ namespace ignition
                                         const std::string &_nUuid,
                                         const std::string &_msgTypeName,
                                         const AdvertiseMessageOptions &_opts);
-
-      /// \brief Copy constructor.
-      /// \param[in] _other Other MessagePublisher object.
-      public: MessagePublisher(const MessagePublisher &_other);
 
       /// \brief Destructor.
       public: virtual ~MessagePublisher() = default;
@@ -284,11 +271,6 @@ namespace ignition
       /// \return True if this object does not match the provided object.
       public: bool operator!=(const MessagePublisher &_pub) const;
 
-      /// \brief Assignment operator.
-      /// \param[in] _other The other MessagePublisher.
-      /// \return A reference to this instance.
-      public: MessagePublisher &operator=(const MessagePublisher &_other);
-
 #ifdef _WIN32
 // Disable warning C4251 which is triggered by
 // std::unique_ptr
@@ -333,10 +315,6 @@ namespace ignition
                                const std::string &_reqType,
                                const std::string &_repType,
                                const AdvertiseServiceOptions &_opts);
-
-      /// \brief Copy constructor.
-      /// \param[in] _other Other ServicePublisher object.
-      public: ServicePublisher(const ServicePublisher &_other);
 
       /// \brief Destructor.
       public: virtual ~ServicePublisher() = default;

--- a/src/Publisher.cc
+++ b/src/Publisher.cc
@@ -42,13 +42,6 @@ Publisher::Publisher(const std::string &_topic, const std::string &_addr,
 }
 
 //////////////////////////////////////////////////
-Publisher::Publisher(const Publisher &_other)
-  : Publisher()
-{
-  (*this) = _other;
-}
-
-//////////////////////////////////////////////////
 std::string Publisher::Topic() const
 {
   return this->topic;
@@ -170,17 +163,6 @@ bool Publisher::operator!=(const Publisher &_pub) const
 }
 
 //////////////////////////////////////////////////
-Publisher &Publisher::operator=(const Publisher &_other)
-{
-  this->SetTopic(_other.Topic());
-  this->SetAddr(_other.Addr());
-  this->SetPUuid(_other.PUuid());
-  this->SetNUuid(_other.NUuid());
-  this->SetOptions(_other.Options());
-  return *this;
-}
-
-//////////////////////////////////////////////////
 MessagePublisher::MessagePublisher(const std::string &_topic,
   const std::string &_addr, const std::string &_ctrl, const std::string &_pUuid,
   const std::string &_nUuid, const std::string &_msgTypeName,
@@ -190,13 +172,6 @@ MessagePublisher::MessagePublisher(const std::string &_topic,
     msgTypeName(_msgTypeName),
     msgOpts(_opts)
 {
-}
-
-//////////////////////////////////////////////////
-MessagePublisher::MessagePublisher(const MessagePublisher &_other)
-  : MessagePublisher()
-{
-  (*this) = _other;
 }
 
 //////////////////////////////////////////////////
@@ -276,16 +251,6 @@ bool MessagePublisher::operator!=(const MessagePublisher &_pub) const
 }
 
 //////////////////////////////////////////////////
-MessagePublisher &MessagePublisher::operator=(const MessagePublisher &_other)
-{
-  Publisher::operator=(_other);
-  this->SetCtrl(_other.Ctrl());
-  this->SetMsgTypeName(_other.MsgTypeName());
-  this->SetOptions(_other.Options());
-  return *this;
-}
-
-//////////////////////////////////////////////////
 ServicePublisher::ServicePublisher(const std::string &_topic,
   const std::string &_addr, const std::string &_socketId,
   const std::string &_pUuid, const std::string &_nUuid,
@@ -299,12 +264,6 @@ ServicePublisher::ServicePublisher(const std::string &_topic,
 {
 }
 
-//////////////////////////////////////////////////
-ServicePublisher::ServicePublisher(const ServicePublisher &_other)
-  : ServicePublisher()
-{
-  (*this) = _other;
-}
 
 //////////////////////////////////////////////////
 std::string ServicePublisher::SocketId() const


### PR DESCRIPTION
Targeting `main`, because I'm not sure if this breaks API.

We were defining copy and assignment operators that aren't necessary and broke rule of three/rule of five.

Signed-off-by: Michael Carroll <michael@openrobotics.org>