### PR TITLE
Consider all network interfaces when checking HOST option.

### DIFF
--- a/include/ignition/transport/Discovery.hh
+++ b/include/ignition/transport/Discovery.hh
@@ -898,6 +898,10 @@ namespace ignition
           this->SendUnicast(msg);
         }
 
+        bool isSenderLocal = (std::find(this->hostInterfaces.begin(),
+          this->hostInterfaces.end(), _fromIp) != this->hostInterfaces.end()) ||
+          _fromIp == "127.0.0.1";
+
         // Update timestamp and cache the callbacks.
         DiscoveryCallback<Pub> connectCb;
         DiscoveryCallback<Pub> disconnectCb;
@@ -923,7 +927,7 @@ namespace ignition
             // Check scope of the topic.
             if ((publisher.Options().Scope() == Scope_t::PROCESS) ||
                 (publisher.Options().Scope() == Scope_t::HOST &&
-                 _fromIp != this->hostAddr))
+                 !isSenderLocal))
             {
               return;
             }
@@ -976,7 +980,7 @@ namespace ignition
               // Check scope of the topic.
               if ((nodeInfo.Options().Scope() == Scope_t::PROCESS) ||
                   (nodeInfo.Options().Scope() == Scope_t::HOST &&
-                   _fromIp != this->hostAddr))
+                   !isSenderLocal))
               {
                 continue;
               }
@@ -1048,7 +1052,7 @@ namespace ignition
             // Check scope of the topic.
             if ((publisher.Options().Scope() == Scope_t::PROCESS) ||
                 (publisher.Options().Scope() == Scope_t::HOST &&
-                 _fromIp != this->hostAddr))
+                 !isSenderLocal))
             {
               return;
             }

--- a/include/ignition/transport/Discovery.hh
+++ b/include/ignition/transport/Discovery.hh
@@ -900,7 +900,7 @@ namespace ignition
 
         bool isSenderLocal = (std::find(this->hostInterfaces.begin(),
           this->hostInterfaces.end(), _fromIp) != this->hostInterfaces.end()) ||
-          _fromIp == "127.0.0.1";
+          (_fromIp.find("127.") == 0);
 
         // Update timestamp and cache the callbacks.
         DiscoveryCallback<Pub> connectCb;


### PR DESCRIPTION
Signed-off-by: Carlos Agüero <caguero@openrobotics.org>

<!-- 
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://ignitionrobotics.org/docs/all/contributing
-->

# 🦟 Bug fix

Fixes the following issue:

One publisher sets `IGN_IP` to `127.0.0.1` and advertises a topic with `Scope_T::Host`. With these settings, a default subscriber is unable to receive any messages.

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

The problem was that we were only checking if the source IP received was matching the host address used by the receiver. Now, we're checking if the source IP received matches any of the network interfaces or localhost.

To test (from the `examples` directory:

Terminal 1: `IGN_IP=127.0.0.1 ./publisher`
Terminal 2: `./subscriber`

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [X] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
