### PR TITLE
Output errno in unicast error msg during discrovery.

### DIFF
--- a/include/ignition/transport/Discovery.hh
+++ b/include/ignition/transport/Discovery.hh
@@ -1177,7 +1177,7 @@ namespace ignition
             if (sent != totalSize)
             {
               std::cerr << "Exception sending a unicast message: "
-                  << strerror(errno) << std::endl;
+                  << strerror(errno) << ". Return value: " << sent << std::endl;
               break;
             }
           }

--- a/include/ignition/transport/Discovery.hh
+++ b/include/ignition/transport/Discovery.hh
@@ -1166,6 +1166,7 @@ namespace ignition
           // Send the discovery message to the unicast relays.
           for (const auto &sockAddr : this->relayAddrs)
           {
+            errno = 0;
             auto sent = sendto(this->sockets.at(0),
               reinterpret_cast<const raw_type *>(
                 reinterpret_cast<const unsigned char*>(buffer)),
@@ -1175,7 +1176,8 @@ namespace ignition
 
             if (sent != totalSize)
             {
-              std::cerr << "Exception sending a unicast message" << std::endl;
+              std::cerr << "Exception sending a unicast message: "
+                  << strerror(errno) << std::endl;
               break;
             }
           }
@@ -1235,7 +1237,7 @@ namespace ignition
               // * https://stackoverflow.com/questions/16555101/sendto-dgrams-do-not-block-for-enobufs-on-osx
               if (errno != EPERM && errno != ENOBUFS)
               {
-                std::cerr << "Exception sending a multicast message:"
+                std::cerr << "Exception sending a multicast message: "
                   << strerror(errno) << std::endl;
               }
               break;


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

Output `errno` to give more info on what the actual error is. I copied the code from multicast but omitted checking for `EPERM` and `ENOBUFS`. Let me know if that's needed.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

