### PR TITLE
9 1 1 prep

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(ignition-transport9 VERSION 9.1.0)
+project(ignition-transport9 VERSION 9.1.1)
 
 #============================================================================
 # Find ignition-cmake

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,26 @@
 
 ### Ignition Transport 9.X.X
 
+### Ignition Transport 9.1.1 (2021-01-05)
+
+1. Add errno output for discovery.
+   * [Github pull request 254](https://github.com/ignitionrobotics/ign-transport/pull/254)
+
+1. Consider all network interfaces when checking HOST option.
+   * [Github pull request 245](https://github.com/ignitionrobotics/ign-transport/pull/245)
+
+1. Remove tools/code_check and update codecov. 
+   * [Github pull request 246](https://github.com/ignitionrobotics/ign-transport/pull/246)
+
+1. Remove deprecated test.
+   * [Github pull request 239](https://github.com/ignitionrobotics/ign-transport/pull/239)
+
+1. Master branch updates.
+   * [Github pull request 224](https://github.com/ignitionrobotics/ign-transport/pull/224)
+
+1. Add windows installation.
+   * [Github pull request 214](https://github.com/ignitionrobotics/ign-transport/pull/214)
+
 ### Ignition Transport 9.1.0 (2021-01-05)
 
 1. All changes up to version 8.2.0.


### PR DESCRIPTION
# 🎈 Release

Preparation for 9.1.1 release.

Comparison to 9.1.1: https://github.com/ignitionrobotics/ign-transport/compare/ignition-transport9_9.1.0...ign-transport9

## Checklist
- [ ] Asked team if this is a good time for a release
- [X] There are no changes to be ported from the previous major version
- [X] No PRs targeted at this major version are close to getting in
- [X] Bumped minor for new features, patch for bug fixes
- [X] Updated changelog
- [] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [ignition-release](https://github.com/ignition-release) (as needed): <LINK>

**Note to maintainers**: Remember to use **Squash-Merge**
