### PR TITLE
NetUtils: simplify logic in determineInterfaces

### DIFF
--- a/src/NetUtils.cc
+++ b/src/NetUtils.cc
@@ -231,15 +231,8 @@ inline namespace IGNITION_TRANSPORT_VERSION_NAMESPACE
       // Is not running.
       if (!(ifa->ifa_flags & IFF_UP))
         continue;
-      // IPv6 interface.
-      if (ifa->ifa_addr->sa_family == AF_INET6)
-        interface = std::string(ip_);
-      // Private network interface.
-      else if (isPrivateIP(ip_))
-        interface = std::string(ip_);
       // Any other interface.
-      else
-        interface = std::string(ip_);
+      interface = std::string(ip_);
 
       // Add the new interface if it's new and unique.
       if (!interface.empty() &&

--- a/src/NetUtils.cc
+++ b/src/NetUtils.cc
@@ -165,7 +165,6 @@ inline namespace IGNITION_TRANSPORT_VERSION_NAMESPACE
       std::cerr << "error in getifaddrs: " << strerror(rc) << std::endl;
       exit(-1);
     }
-    char preferred_ip[200] = {0};
 
 #if defined(SIOCGIFINDEX)
     // Open a socket to use IOCTL later.
@@ -233,14 +232,13 @@ inline namespace IGNITION_TRANSPORT_VERSION_NAMESPACE
       if (!(ifa->ifa_flags & IFF_UP))
         continue;
       // IPv6 interface.
-      if (ifa->ifa_addr->sa_family == AF_INET6 && !preferred_ip[0])
+      if (ifa->ifa_addr->sa_family == AF_INET6)
         interface = std::string(ip_);
       // Private network interface.
-      else if (isPrivateIP(ip_) && !preferred_ip[0])
+      else if (isPrivateIP(ip_))
         interface = std::string(ip_);
       // Any other interface.
-      else if (!isPrivateIP(ip_) &&
-               (isPrivateIP(preferred_ip) || !preferred_ip[0]))
+      else
         interface = std::string(ip_);
 
       // Add the new interface if it's new and unique.


### PR DESCRIPTION
# 🦟 Bug fix

Removes an unused variable and simplifies complex logic in `determineInterfaces` method.

## Summary

* 2f6056b: The `preferred_ip` array is initialized to `{0}` and no code writes to it; it is only read from, so just remove it.
* 61ce68f: Now there is an if/else if/else block that runs the same code in each branch, so just remove the logic and run that code unconditionally.

I believe this is functionally equivalent to the current code.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [X] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
