### PR TITLE
Fix typo in "nodes and topics" tutorial

### DIFF
--- a/tutorials/03_nodesAndTopics.md
+++ b/tutorials/03_nodesAndTopics.md
@@ -51,7 +51,7 @@ The following symbols are not allowed as part of the topic name: `@`, `:=`, `~`.
 | //image     | Invalid  | Contains two consecutive `//` |
 | /           | Invalid  | `/` topic is not allowed      |
 | ~myTopic    | Invalid  | Symbol `~` not allowed        |
-| @myTopic    | Invalid  | Symbol `@` not allowed        |
+| `@`myTopic    | Invalid  | Symbol `@` not allowed        |
 | myTopic:=   | Invalid  | Symbol `:=` not allowed       |
 
 ## Topic scope


### PR DESCRIPTION
Signed-off-by: Carlos Agüero <caguero@openrobotics.org>

# 🦟 Bug fix

Fixes minor typo in a tutorial.

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

The tutorial tells you that a topic containing a `@` isn't valid but the `@` wasn't rendered correctly.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**