### PR TITLE
Fix protobuf dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,15 @@ project(ignition-transport11 VERSION 11.0.0)
 find_package(ignition-cmake2 2.8.0 REQUIRED)
 set(IGN_CMAKE_VER ${ignition-cmake2_VERSION_MAJOR})
 
+# Setting this policy enables using the protobuf_MODULE_COMPATIBLE
+# set command in CMake versions older than 13.13
+set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
+# This option is needed to use the PROTOBUF_GENERATE_CPP
+# in case protobuf is found with the CMake config files
+# It needs to be set before any find_package(...) call
+# as protobuf could be find transitively by any dependency
+set(protobuf_MODULE_COMPATIBLE TRUE)
+
 #============================================================================
 # Configure the project
 #============================================================================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,13 +5,6 @@ cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 #============================================================================
 project(ignition-transport11 VERSION 11.0.0)
 
-#============================================================================
-# Find ignition-cmake
-#============================================================================
-# If you get an error at this line, you need to install ignition-cmake
-find_package(ignition-cmake2 2.8.0 REQUIRED)
-set(IGN_CMAKE_VER ${ignition-cmake2_VERSION_MAJOR})
-
 # Setting this policy enables using the protobuf_MODULE_COMPATIBLE
 # set command in CMake versions older than 13.13
 set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
@@ -20,6 +13,13 @@ set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
 # It needs to be set before any find_package(...) call
 # as protobuf could be find transitively by any dependency
 set(protobuf_MODULE_COMPATIBLE TRUE)
+
+#============================================================================
+# Find ignition-cmake
+#============================================================================
+# If you get an error at this line, you need to install ignition-cmake
+find_package(ignition-cmake2 2.8.0 REQUIRED)
+set(IGN_CMAKE_VER ${ignition-cmake2_VERSION_MAJOR})
 
 #============================================================================
 # Configure the project


### PR DESCRIPTION
Signed-off-by: Jorge Perez <jjperez@ekumenlabs.com>

# 🦟 Bug fix

Fixes https://github.com/ignitionrobotics/ign-gazebo/issues/990

## Summary
This is a continuation of https://github.com/ignitionrobotics/ign-gazebo/pull/1046. The original fix solved issues with the `ign-gazebo` jobs of the ignition buildfarm, but the pr jobs still have this problem.

Currently the error appears only in `win-windows_nuc.win10`. I'll test ign-gazebo-pr-win job to get this issue addressed.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**