### PR TITLE
Use libexec to install lib binaries

### DIFF
--- a/src/cmd/CMakeLists.txt
+++ b/src/cmd/CMakeLists.txt
@@ -22,7 +22,7 @@ target_link_libraries(${topic_executable}
   ignition-utils${IGN_UTILS_VER}::cli
   ${PROJECT_LIBRARY_TARGET_NAME}
 )
-install(TARGETS ${topic_executable} DESTINATION ${IGN_LIB_INSTALL_DIR}/ignition/${IGN_DESIGNATION}${PROJECT_VERSION_MAJOR}/)
+install(TARGETS ${topic_executable} DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}/ignition/${IGN_DESIGNATION}${PROJECT_VERSION_MAJOR}/)
 
 # Build service CLI executable
 set(service_executable ign-transport-service)
@@ -32,7 +32,7 @@ target_link_libraries(${service_executable}
   ignition-utils${IGN_UTILS_VER}::cli
   ${PROJECT_LIBRARY_TARGET_NAME}
 )
-install(TARGETS ${service_executable} DESTINATION ${IGN_LIB_INSTALL_DIR}/ignition/${IGN_DESIGNATION}${PROJECT_VERSION_MAJOR}/)
+install(TARGETS ${service_executable} DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}/ignition/${IGN_DESIGNATION}${PROJECT_VERSION_MAJOR}/)
 
 # Build the unit tests.
 ign_build_tests(TYPE UNIT SOURCES ${gtest_sources}


### PR DESCRIPTION
We are installing the cli11 binaries in under the standard library path which is something that does not fit well according to the [FHR](https://refspecs.linuxfoundation.org/FHS_3.0/fhs-3.0.html#usrlibexec). libexec seems a better place for them:

```
4.7.1. Purpose

/usr/libexec includes internal binaries that are not intended to be executed directly by users or shell scripts. Applications may use a single subdirectory under /usr/libexec.
```
