### PR TITLE
Try USER variable to retrieve the username.

### DIFF
--- a/src/NetUtils.cc
+++ b/src/NetUtils.cc
@@ -379,6 +379,15 @@ inline namespace IGNITION_TRANSPORT_VERSION_NAMESPACE
     GetUserName(buffer, &usernameLen);
     return buffer;
 #else
+    // First, try to get the username through the standard environment variable
+    // for it.
+    const auto userVariable = std::getenv("USER");
+    if (userVariable)
+    {
+      return userVariable;
+    }
+
+    // No USER variable, request it from the system.
     struct passwd pd;
     struct passwd *pdResult;
     Uuid uuid;


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
This resolves a situation where gazebo is endlessly spamming:
```
Error getting username: no matching password record.
```
In our case, this triggered because a system was configured with ldap, but at runtime the `libnss_systemd` library wasn't available. This meant the user name lookup through ldap failed, and the fallback by reading it from `/etc/passwd` didn't work as the user wasn't present there. It can probably be reproduced by making the `getpwuid_r` always fail.

Basically, all this complexity can be removed by just checking the `$USER` environment variable. That is unlikely to fail on any linux system. I left the old behaviour in place as a fallback for if `USER` is not set, but I can't think of a situation where that would be.


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests -> there's one that checks if the user name is empty [here](https://github.com/ignitionrobotics/ign-transport/blob/a4a946086a5d2180f918675d8678a778451de37a/src/NetUtils_TEST.cc#L34)
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
