### PR TITLE
Add option to output messages in JSON format

### DIFF
--- a/src/cmd/ign.cc
+++ b/src/cmd/ign.cc
@@ -17,6 +17,7 @@
 
 #include <chrono>
 #include <functional>
+#include <google/protobuf/util/json_util.h>
 #include <iostream>
 #include <string>
 #include <vector>
@@ -251,7 +252,7 @@ extern "C" void cmdServiceReq(const char *_service,
 
 //////////////////////////////////////////////////
 extern "C" void cmdTopicEcho(const char *_topic,
-  const double _duration, int _count)
+  const double _duration, int _count, bool jsonOutput)
 {
   if (!_topic || std::string(_topic).empty())
   {
@@ -266,7 +267,16 @@ extern "C" void cmdTopicEcho(const char *_topic,
   std::function<void(const ProtoMsg&)> cb = [&](const ProtoMsg &_msg)
   {
     std::lock_guard<std::mutex> lock(mutex);
-    std::cout << _msg.DebugString() << std::endl;
+    if (jsonOutput)
+    {
+      std::string jsonStr;
+      google::protobuf::util::MessageToJsonString(_msg, &jsonStr);
+      std::cout << jsonStr << std::endl;
+    }
+    else
+    {
+      std::cout << _msg.DebugString() << std::endl;
+    }
     ++count;
     condition.notify_one();
   };

--- a/src/cmd/ign.hh
+++ b/src/cmd/ign.hh
@@ -63,6 +63,21 @@ extern "C" void cmdServiceReq(const char *_service,
                                                          const int _timeout,
                                                          const char *_reqData);
 
+extern "C" {
+  /// \brief Enum used for specifing the message output format for functions
+  /// like cmdTopicEcho.
+  enum class MsgOutputFormat {
+    // Default. Currently, this is Protobuf's DebugString output format.
+    kDefault,
+
+    // Output format used in Protobuf's Message::DebugString.
+    kDebugString,
+
+    // JSON output.
+    kJSON
+  };
+}
+
 /// \brief External hook to execute 'ign topic -e' from the command line.
 /// The _duration parameter overrides the _count parameter.
 /// \param[in] _topic Topic name.
@@ -71,10 +86,9 @@ extern "C" void cmdServiceReq(const char *_service,
 /// \param[in] _count Number of messages to echo and then stop. A value <= 0
 /// indicates no limit. The _duration parameter overrides the _count
 /// parameter.
-/// \param[in] _jsonOutput If true, message output will be in JSON format.
-/// Otherwise, Protobuf's default DebugString format will be used.
+/// \param[in] _outputFormat Message output format.
 extern "C" void cmdTopicEcho(const char *_topic, const double _duration,
-                             int _count, bool _jsonOutput);
+                             int _count, MsgOutputFormat _outputFormat);
 
 /// \brief External hook to read the library version.
 /// \return C-string representing the version. Ex.: 0.1.2

--- a/src/cmd/ign.hh
+++ b/src/cmd/ign.hh
@@ -71,9 +71,10 @@ extern "C" void cmdServiceReq(const char *_service,
 /// \param[in] _count Number of messages to echo and then stop. A value <= 0
 /// indicates no limit. The _duration parameter overrides the _count
 /// parameter.
-extern "C" void cmdTopicEcho(const char *_topic,
-                                                        const double _duration,
-                                                        int _count);
+/// \param[in] _jsonOutput If true, message output will be in JSON format.
+/// Otherwise, Protobuf's default DebugString format will be used.
+extern "C" void cmdTopicEcho(const char *_topic, const double _duration,
+                             int _count, bool _jsonOutput);
 
 /// \brief External hook to read the library version.
 /// \return C-string representing the version. Ex.: 0.1.2

--- a/src/cmd/ign_src_TEST.cc
+++ b/src/cmd/ign_src_TEST.cc
@@ -230,11 +230,11 @@ TEST(ignTest, cmdTopicEcho)
   transport::Node node;
 
   // Requesting a null topic should trigger an error message.
-  cmdTopicEcho(nullptr, 10.00, 0);
+  cmdTopicEcho(nullptr, 10.00, 0, false);
   EXPECT_EQ(stdErrBuffer.str(), "Invalid topic. Topic must not be empty.\n");
   clearIOStreams(stdOutBuffer, stdErrBuffer);
 
-  cmdTopicEcho(kInvalidTopic.c_str(), 5.00, 0);
+  cmdTopicEcho(kInvalidTopic.c_str(), 5.00, 0, false);
   EXPECT_EQ(stdErrBuffer.str(), "Topic [/] is not valid.\n");
   clearIOStreams(stdOutBuffer, stdErrBuffer);
 

--- a/src/cmd/ign_src_TEST.cc
+++ b/src/cmd/ign_src_TEST.cc
@@ -230,11 +230,11 @@ TEST(ignTest, cmdTopicEcho)
   transport::Node node;
 
   // Requesting a null topic should trigger an error message.
-  cmdTopicEcho(nullptr, 10.00, 0, false);
+  cmdTopicEcho(nullptr, 10.00, 0, MsgOutputFormat::kDefault);
   EXPECT_EQ(stdErrBuffer.str(), "Invalid topic. Topic must not be empty.\n");
   clearIOStreams(stdOutBuffer, stdErrBuffer);
 
-  cmdTopicEcho(kInvalidTopic.c_str(), 5.00, 0, false);
+  cmdTopicEcho(kInvalidTopic.c_str(), 5.00, 0, MsgOutputFormat::kDefault);
   EXPECT_EQ(stdErrBuffer.str(), "Topic [/] is not valid.\n");
   clearIOStreams(stdOutBuffer, stdErrBuffer);
 

--- a/src/cmd/topic_main.cc
+++ b/src/cmd/topic_main.cc
@@ -53,6 +53,8 @@ struct TopicOptions
 
   /// \brief Number of messages to echo
   int count{-1};
+
+  bool jsonOutput{false};
 };
 
 //////////////////////////////////////////////////
@@ -73,7 +75,8 @@ void runTopicCommand(const TopicOptions &_opt)
                   _opt.msgData.c_str());
       break;
     case TopicCommand::kTopicEcho:
-      cmdTopicEcho(_opt.topic.c_str(), _opt.duration, _opt.count);
+      cmdTopicEcho(_opt.topic.c_str(), _opt.duration, _opt.count,
+                   _opt.jsonOutput);
       break;
     case TopicCommand::kNone:
     default:
@@ -118,6 +121,10 @@ void addTopicFlags(CLI::App &_app)
     [opt](){
       opt->command = TopicCommand::kTopicEcho;
     });
+
+  command->add_flag_callback("--json-output",
+      [opt]() { opt->jsonOutput = true; },
+      "Output messages in JSON format");
 
   command->add_option_function<std::string>("-p,--pub",
       [opt](const std::string &_msgData){

--- a/src/cmd/topic_main.cc
+++ b/src/cmd/topic_main.cc
@@ -54,7 +54,8 @@ struct TopicOptions
   /// \brief Number of messages to echo
   int count{-1};
 
-  bool jsonOutput{false};
+  /// \brief Message output format
+  MsgOutputFormat msgOutputFormat {MsgOutputFormat::kDefault};
 };
 
 //////////////////////////////////////////////////
@@ -76,7 +77,7 @@ void runTopicCommand(const TopicOptions &_opt)
       break;
     case TopicCommand::kTopicEcho:
       cmdTopicEcho(_opt.topic.c_str(), _opt.duration, _opt.count,
-                   _opt.jsonOutput);
+                   _opt.msgOutputFormat);
       break;
     case TopicCommand::kNone:
     default:
@@ -123,7 +124,7 @@ void addTopicFlags(CLI::App &_app)
     });
 
   command->add_flag_callback("--json-output",
-      [opt]() { opt->jsonOutput = true; },
+      [opt]() { opt->msgOutputFormat = MsgOutputFormat::kJSON; },
       "Output messages in JSON format");
 
   command->add_option_function<std::string>("-p,--pub",


### PR DESCRIPTION
# 🎉 New feature

## Summary

This adds a command line option `--json-output` to allow output in JSON format instead of Protobuf's default `DebugString` format. This would useful for manipulating message output with tools like `jq`. For example, if we wanted to extract just the `x` component of a `Pose` message, we could do

`ign topic -e --json-output -t /pose_topic | jq '.position.x'`


## Test it
<!--Explain how reviewers can test this new feature manually.-->

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
