### PR TITLE
Remove Username Error Messages

### DIFF
--- a/src/NetUtils.cc
+++ b/src/NetUtils.cc
@@ -401,14 +401,6 @@ inline namespace IGNITION_TRANSPORT_VERSION_NAMESPACE
           result = pd.pw_name;
           break;
         }
-        else
-        {
-          std::cerr << "Error getting username: no matching password record.\n";
-        }
-      }
-      else
-      {
-        std::cerr << "Error getting username: " << strerror(errno) << std::endl;
       }
     }
 


### PR DESCRIPTION
Fixes #286 

## Summary
Removes the error messages that occur during some valid use cases, such as when the /etc/passwd file does not have an entry for a uid + gid due to running in docker with --user uid:gid