### PR TITLE
Typo in help message in topic_main.cc

### DIFF
--- a/src/cmd/topic_main.cc
+++ b/src/cmd/topic_main.cc
@@ -96,7 +96,7 @@ void addTopicFlags(CLI::App &_app)
                                      "Duration (seconds) to run");
   auto countOpt = _app.add_option("-n,--num",
                                   opt->count,
-                                  "Numer of messages to echo and then exit");
+                                  "Number of messages to echo and then exit");
 
   durationOpt->excludes(countOpt);
   countOpt->excludes(durationOpt);


### PR DESCRIPTION
Signed-off-by: Aditya <aditya050995@gmail.com>

# 🦟 Bug fix

## Summary
This PR fixes a minor typo in the help message displayed by the command ``ign topic``.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
