### PR TITLE
Focal CI: static checkers and doxygen linters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,3 +23,7 @@ jobs:
       - name: Compile and test
         id: ci
         uses: ignition-tooling/action-ignition-ci@focal
+        with:
+          cppcheck-enabled: true
+          cpplint-enabled: true
+          doxygen-enabled: true

--- a/include/ignition/transport/AdvertiseOptions.hh
+++ b/include/ignition/transport/AdvertiseOptions.hh
@@ -37,7 +37,7 @@ namespace ignition
     class AdvertiseMessageOptionsPrivate;
     class AdvertiseServiceOptionsPrivate;
 
-    /// \def Scope This strongly typed enum defines the different options for
+    /// \brief This strongly typed enum defines the different options for
     /// the scope of a topic/service.
     enum class Scope_t
     {

--- a/include/ignition/transport/CIface.h
+++ b/include/ignition/transport/CIface.h
@@ -84,6 +84,7 @@ extern "C" {
   /// \brief Subscribe to a topic, and register a callback.
   /// \param[in] _node Pointer to a node.
   /// \param[in] _topic Name of the topic.
+  /// \param[in] _opts Subscriber options.
   /// \param[in] _callback The function to call when a message is received.
   /// \param[in] _userData Arbitrary user data pointer.
   /// \return 0 on success.

--- a/include/ignition/transport/Node.hh
+++ b/include/ignition/transport/Node.hh
@@ -253,7 +253,7 @@ namespace ignition
       /// \param[in] _topic Topic to be subscribed.
       /// \param[in] _callback Pointer to the callback function with the
       /// following parameters:
-      ///   \param[in] _msg Protobuf message containing a new topic update.
+      ///   * _msg Protobuf message containing a new topic update.
       /// \param[in] _opts Subscription options.
       /// \return true when successfully subscribed or false otherwise.
       public: template<typename MessageT>
@@ -267,7 +267,7 @@ namespace ignition
       /// In this version the callback is a lamda function.
       /// \param[in] _topic Topic to be subscribed.
       /// \param[in] _callback Lambda function with the following parameters:
-      ///   \param[in] _msg Protobuf message containing a new topic update.
+      ///   * _msg Protobuf message containing a new topic update.
       /// \param[in] _opts Subscription options.
       /// \return true when successfully subscribed or false otherwise.
       public: template<typename MessageT>
@@ -282,7 +282,7 @@ namespace ignition
       /// \param[in] _topic Topic to be subscribed.
       /// \param[in] _callback Pointer to the callback function with the
       /// following parameters:
-      ///   \param[in] _msg Protobuf message containing a new topic update.
+      ///   * _msg Protobuf message containing a new topic update.
       /// \param[in] _obj Instance containing the member function.
       /// \param[in] _opts Subscription options.
       /// \return true when successfully subscribed or false otherwise.
@@ -299,8 +299,8 @@ namespace ignition
       /// \param[in] _topic Topic to be subscribed.
       /// \param[in] _callback Pointer to the callback function with the
       /// following parameters:
-      ///   \param[in] _msg Protobuf message containing a new topic update.
-      ///   \param[in] _info Message information (e.g.: topic name).
+      ///   * _msg Protobuf message containing a new topic update.
+      ///   * _info Message information (e.g.: topic name).
       /// \param[in] _opts Subscription options.
       /// \return true when successfully subscribed or false otherwise.
       public: template<typename MessageT>
@@ -314,8 +314,8 @@ namespace ignition
       /// In this version the callback is a lamda function.
       /// \param[in] _topic Topic to be subscribed.
       /// \param[in] _callback Lambda function with the following parameters:
-      ///   \param[in] _msg Protobuf message containing a new topic update.
-      ///   \param[in] _info Message information (e.g.: topic name).
+      ///   * _msg Protobuf message containing a new topic update.
+      ///   * _info Message information (e.g.: topic name).
       /// \param[in] _opts Subscription options.
       /// \return true when successfully subscribed or false otherwise.
       public: template<typename MessageT>
@@ -331,8 +331,8 @@ namespace ignition
       /// \param[in] _topic Topic to be subscribed.
       /// \param[in] _callback Pointer to the callback function with the
       /// following parameters:
-      ///   \param[in] _msg Protobuf message containing a new topic update.
-      ///   \param[in] _info Message information (e.g.: topic name).
+      ///   * _msg Protobuf message containing a new topic update.
+      ///   * _info Message information (e.g.: topic name).
       /// \param[in] _obj Instance containing the member function.
       /// \param[in] _opts Subscription options.
       /// \return true when successfully subscribed or false otherwise.
@@ -361,9 +361,9 @@ namespace ignition
       /// \param[in] _topic Topic name associated to the service.
       /// \param[in] _callback Callback to handle the service request with the
       /// following parameters:
-      ///   \param[in] _request Protobuf message containing the request.
-      ///   \param[out] _reply Protobuf message containing the response.
-      ///   \return Service call result.
+      ///   * _request Protobuf message containing the request.
+      ///   * _reply Protobuf message containing the response.
+      ///   * Returns Service call result.
       /// \param[in] _options Advertise options.
       /// \return true when the topic has been successfully advertised or
       /// false otherwise.
@@ -379,8 +379,8 @@ namespace ignition
       /// \param[in] _topic Topic name associated to the service.
       /// \param[in] _callback Callback to handle the service request with the
       /// following parameters:
-      ///   \param[out] _reply Protobuf message containing the response.
-      ///   \return Service call result.
+      ///   * _reply Protobuf message containing the response.
+      ///   * Returns Service call result.
       /// \param[in] _options Advertise options.
       /// \return true when the topic has been successfully advertised or
       /// false otherwise.
@@ -396,7 +396,7 @@ namespace ignition
       /// \param[in] _topic Topic name associated to the service.
       /// \param[in] _callback Callback to handle the service request with the
       /// following parameters:
-      ///   \param[in] _request Protobuf message containing the request.
+      ///   * _request Protobuf message containing the request.
       /// \param[in] _options Advertise options.
       /// \return true when the topic has been successfully advertised or
       /// false otherwise.
@@ -412,9 +412,9 @@ namespace ignition
       /// \param[in] _topic Topic name associated to the service.
       /// \param[in] _callback Callback to handle the service request with the
       /// following parameters:
-      ///   \param[in] _request Protobuf message containing the request.
-      ///   \param[out] _reply Protobuf message containing the response.
-      ///   \return Service call result.
+      ///   * _request Protobuf message containing the request.
+      ///   * _reply Protobuf message containing the response.
+      ///   * Returns Service call result.
       /// \param[in] _options Advertise options.
       /// \return true when the topic has been successfully advertised or
       /// false otherwise.
@@ -431,8 +431,8 @@ namespace ignition
       /// \param[in] _topic Topic name associated to the service.
       /// \param[in] _callback Callback to handle the service request with the
       /// following parameters:
-      ///   \param[out] _reply Protobuf message containing the response.
-      ///   \return Service call result.
+      ///   * _reply Protobuf message containing the response.
+      ///   * Returns Service call result.
       /// \param[in] _options Advertise options.
       /// \return true when the topic has been successfully advertised or
       /// false otherwise.
@@ -448,7 +448,7 @@ namespace ignition
       /// \param[in] _topic Topic name associated to the service.
       /// \param[in] _callback Callback to handle the service request with the
       /// following parameters:
-      ///   \param[in] _request Protobuf message containing the request.
+      ///   * _request Protobuf message containing the request.
       /// \param[in] _options Advertise options.
       /// \return true when the topic has been successfully advertised or
       /// false otherwise.
@@ -464,9 +464,9 @@ namespace ignition
       /// \param[in] _topic Topic name associated to the service.
       /// \param[in] _callback Callback to handle the service request with the
       /// following parameters:
-      ///   \param[in] _request Protobuf message containing the request.
-      ///   \param[out] _reply Protobuf message containing the response.
-      ///   \return Service call result.
+      ///   * _request Protobuf message containing the request.
+      ///   * _reply Protobuf message containing the response.
+      ///   * Returns Service call result.
       /// \param[in] _obj Instance containing the member function.
       /// \param[in] _options Advertise options.
       /// \return true when the topic has been successfully advertised or
@@ -484,8 +484,8 @@ namespace ignition
       /// \param[in] _topic Topic name associated to the service.
       /// \param[in] _callback Callback to handle the service request with the
       /// following parameters:
-      ///   \param[out] _reply Protobuf message containing the response.
-      ///   \return Service call result.
+      ///   * _reply Protobuf message containing the response.
+      ///   * Returns Service call result.
       /// \param[in] _obj Instance containing the member function.
       /// \param[in] _options Advertise options.
       /// \return true when the topic has been successfully advertised or
@@ -503,7 +503,7 @@ namespace ignition
       /// \param[in] _topic Topic name associated to the service.
       /// \param[in] _callback Callback to handle the service request with the
       /// following parameters:
-      ///   \param[in] _request Protobuf message containing the request.
+      ///   * _request Protobuf message containing the request.
       /// \param[in] _obj Instance containing the member function.
       /// \param[in] _options Advertise options.
       /// \return true when the topic has been successfully advertised or
@@ -527,8 +527,8 @@ namespace ignition
       /// parameters.
       /// \param[in] _callback Pointer to the callback function executed when
       /// the response arrives. The callback has the following parameters:
-      ///   \param[in] _reply Protobuf message containing the response.
-      ///   \param[in] _result Result of the service call. If false, there was
+      ///   * _reply Protobuf message containing the response.
+      ///   * _result Result of the service call. If false, there was
       ///   a problem executing your request.
       /// \return true when the service call was succesfully requested.
       public: template<typename RequestT, typename ReplyT>
@@ -543,8 +543,8 @@ namespace ignition
       /// \param[in] _topic Service name requested.
       /// \param[in] _callback Pointer to the callback function executed when
       /// the response arrives. The callback has the following parameters:
-      ///   \param[in] _reply Protobuf message containing the response.
-      ///   \param[in] _result Result of the service call. If false, there was
+      ///   * _reply Protobuf message containing the response.
+      ///   * _result Result of the service call. If false, there was
       ///   a problem executing your request.
       /// \return true when the service call was succesfully requested.
       public: template<typename ReplyT>
@@ -559,8 +559,8 @@ namespace ignition
       /// parameters.
       /// \param[in] _callback Lambda function executed when the response
       /// arrives. The callback has the following parameters:
-      ///   \param[in] _reply Protobuf message containing the response.
-      ///   \param[in] _result Result of the service call. If false, there was
+      ///   * _reply Protobuf message containing the response.
+      ///   * _result Result of the service call. If false, there was
       ///   a problem executing your request.
       /// \return true when the service call was succesfully requested.
       public: template<typename RequestT, typename ReplyT>
@@ -576,8 +576,8 @@ namespace ignition
       /// \param[in] _topic Service name requested.
       /// \param[in] _callback Lambda function executed when the response
       /// arrives. The callback has the following parameters:
-      ///   \param[in] _reply Protobuf message containing the response.
-      ///   \param[in] _result Result of the service call. If false, there was
+      ///   * _reply Protobuf message containing the response.
+      ///   * _result Result of the service call. If false, there was
       ///   a problem executing your request.
       /// \return true when the service call was succesfully requested.
       public: template<typename ReplyT>
@@ -593,8 +593,8 @@ namespace ignition
       /// parameters.
       /// \param[in] _callback Pointer to the callback function executed when
       /// the response arrives. The callback has the following parameters:
-      ///   \param[in] _reply Protobuf message containing the response.
-      ///   \param[in] _result Result of the service call. If false, there was
+      ///   * _reply Protobuf message containing the response.
+      ///   * _result Result of the service call. If false, there was
       ///   a problem executing your request.
       /// \param[in] _obj Instance containing the member function.
       /// \return true when the service call was succesfully requested.
@@ -611,8 +611,8 @@ namespace ignition
       /// \param[in] _topic Service name requested.
       /// \param[in] _callback Pointer to the callback function executed when
       /// the response arrives. The callback has the following parameters:
-      ///   \param[in] _reply Protobuf message containing the response.
-      ///   \param[in] _result Result of the service call. If false, there was
+      ///   * _reply Protobuf message containing the response.
+      ///   * _result Result of the service call. If false, there was
       ///   a problem executing your request.
       /// \param[in] _obj Instance containing the member function.
       /// \return true when the service call was succesfully requested.

--- a/include/ignition/transport/NodeOptions.hh
+++ b/include/ignition/transport/NodeOptions.hh
@@ -96,7 +96,7 @@ namespace ignition
       /// The symbol '/' is allowed as part of a partition name but just '/' is
       /// not allowed. The symbols '@', '~' and ' ' are not allowed as part of a
       /// partition name. Two or more consecutive slashes ('//') are not allowed
-      /// \param[in] _ns The partition's name.
+      /// \param[in] _partition The partition's name.
       /// The default partition value is created using a combination of your
       /// hostname, followed by ':' and your username. E.g.: "bb9:caguero" .
       /// It's also possible to use the environment variable IGN_PARTITION for

--- a/include/ignition/transport/NodeShared.hh
+++ b/include/ignition/transport/NodeShared.hh
@@ -81,7 +81,7 @@ namespace ignition
       /// \param[in, out] _ffn Deallocation function. This function is
       /// executed by ZeroMQ when the data is published. This function
       /// deallocates the buffer containing the published data.
-      /// \ref http://zeromq.org/blog:zero-copy
+      /// \sa http://zeromq.org/blog:zero-copy
       /// \param[in] _msgType Message type in string format.
       /// \return true when success or false otherwise.
       public: bool Publish(const std::string &_topic,

--- a/include/ignition/transport/Publisher.hh
+++ b/include/ignition/transport/Publisher.hh
@@ -379,6 +379,12 @@ namespace ignition
       /// \param[in] _other Other ServicePublisher object.
       public: ServicePublisher(const ServicePublisher &_other);
 
+      /// \brief Assignment operator.
+      /// \param[in] _other The other Publisher.
+      /// \return A reference to this instance.
+      public: ServicePublisher &operator=(const ServicePublisher &_other)
+          = default;
+
       /// \brief Destructor.
       public: virtual ~ServicePublisher() = default;
 

--- a/include/ignition/transport/Publisher.hh
+++ b/include/ignition/transport/Publisher.hh
@@ -50,7 +50,7 @@ namespace ignition
       /// \param[in] _topic Topic name.
       /// \param[in] _addr ZeroMQ address.
       /// \param[in] _pUuid Process UUID.
-      /// \param[in] _nUUID node UUID.
+      /// \param[in] _nUuid node UUID.
       /// \param[in] _opts The advertise options.
       public: Publisher(const std::string &_topic,
                         const std::string &_addr,
@@ -229,7 +229,7 @@ namespace ignition
       /// \param[in] _addr ZeroMQ address.
       /// \param[in] _ctrl ZeroMQ control address.
       /// \param[in] _pUuid Process UUID.
-      /// \param[in] _nUUID node UUID.
+      /// \param[in] _nUuid node UUID.
       /// \param[in] _msgTypeName Message type advertised by this publisher.
       /// \param[in] _opts Advertise options.
       public: explicit MessagePublisher(const std::string &_topic,
@@ -362,7 +362,7 @@ namespace ignition
       /// \param[in] _addr ZeroMQ address.
       /// \param[in] _id ZeroMQ socket ID.
       /// \param[in] _pUuid Process UUID.
-      /// \param[in] _nUUID node UUID.
+      /// \param[in] _nUuid node UUID.
       /// \param[in] _reqType Message type used in the service request.
       /// \param[in] _repType Message type used in the service response.
       /// \param[in] _opts Advertise options.

--- a/include/ignition/transport/RepHandler.hh
+++ b/include/ignition/transport/RepHandler.hh
@@ -63,7 +63,7 @@ namespace ignition
       /// \brief Executes the local callback registered for this handler.
       /// \param[in] _msgReq Input parameter (Protobuf message).
       /// \param[out] _msgRep Output parameter (Protobuf message).
-      /// \param[out] _result Service call result.
+      /// \return Service call result.
       public: virtual bool RunLocalCallback(const transport::ProtoMsg &_msgReq,
                                             transport::ProtoMsg &_msgRep) = 0;
 
@@ -72,7 +72,7 @@ namespace ignition
       /// to compose a specific protobuf message and will be passed to the
       /// callback function.
       /// \param[out] _rep Out parameter with the data serialized.
-      /// \param[out] _result Service call result.
+      /// \return Service call result.
       public: virtual bool RunCallback(const std::string &_req,
                                        std::string &_rep) = 0;
 
@@ -118,9 +118,9 @@ namespace ignition
 
       /// \brief Set the callback for this handler.
       /// \param[in] _cb The callback with the following parameters:
-      /// \param[in] _req Protobuf message containing the service request params
-      /// \param[out] _rep Protobuf message containing the service response.
-      /// \param[out] _result True when the service response is considered
+      /// * _req Protobuf message containing the service request params
+      /// * _rep Protobuf message containing the service response.
+      /// * Returns true when the service response is considered
       /// successful or false otherwise.
       public: void SetCallback(
         const std::function<bool(const Req &, Rep &)> &_cb)

--- a/include/ignition/transport/ReqHandler.hh
+++ b/include/ignition/transport/ReqHandler.hh
@@ -214,8 +214,8 @@ namespace ignition
 
       /// \brief Set the callback for this handler.
       /// \param[in] _cb The callback with the following parameters:
-      /// \param[in] _rep Protobuf message containing the service response.
-      /// \param[in] _result True when the service request was successful or
+      /// * _rep Protobuf message containing the service response.
+      /// * _result True when the service request was successful or
       /// false otherwise.
       public: void SetCallback(const std::function <void(
         const Rep &_rep, const bool _result)> &_cb)
@@ -242,8 +242,9 @@ namespace ignition
       /// It shouldn't do anything.
       /// \param[in] _repMsg Protofub message containing the variable where
       /// the result will be stored.
-      public: void SetResponse(const Rep * /*_repMsg*/)
+      public: void SetResponse(const Rep *_repMsg)
       {
+        (void)_repMsg;
       }
 
       // Documentation inherited

--- a/include/ignition/transport/TopicUtils.hh
+++ b/include/ignition/transport/TopicUtils.hh
@@ -76,7 +76,7 @@ namespace ignition
       ///              applied to the topic name. If not empty, it will always
       ///              start with a "/". A trailing slash will always be
       ///              removed
-      /// \<TOPIC\>:     The topic name. A trailing slash will always be removed.
+      /// \<TOPIC\>: The topic name. A trailing slash will always be removed.
       ///
       /// Note: Intuitively, you can imagine the fully qualified name as a
       /// UNIX absolute path, where the partition is always sorrounded by "@".

--- a/include/ignition/transport/TopicUtils.hh
+++ b/include/ignition/transport/TopicUtils.hh
@@ -66,17 +66,17 @@ namespace ignition
       /// \brief Get the full topic path given a namespace and a topic name.
       /// A fully qualified topic name's length must not exceed kMaxNameLength.
       /// The fully qualified name follows the next syntax:
-      /// @<PARTITION>@<NAMESPACE>/<TOPIC>
+      /// \@\<PARTITION\>\@\<NAMESPACE\>/\<TOPIC\>
       /// where:
-      /// <PARTITION>: The name of the partition or empty string.
+      /// \<PARTITION\>: The name of the partition or empty string.
       ///              A "/" will be prefixed to the partition name unless is
       ///              empty or it already starts with slash. A trailing slash
       ///              will always be removed.
-      /// <NAMESPACE>: The namespace or empty string. A namespace is a prefix
+      /// \<NAMESPACE\>: The namespace or empty string. A namespace is a prefix
       ///              applied to the topic name. If not empty, it will always
       ///              start with a "/". A trailing slash will always be
       ///              removed
-      /// <TOPIC>:     The topic name. A trailing slash will always be removed.
+      /// \<TOPIC\>:     The topic name. A trailing slash will always be removed.
       ///
       /// Note: Intuitively, you can imagine the fully qualified name as a
       /// UNIX absolute path, where the partition is always sorrounded by "@".
@@ -110,10 +110,11 @@ namespace ignition
       ///
       /// Given a fully qualified topic name with the following syntax:
       ///
-      /// @<PARTITION>@<NAMESPACE>/<TOPIC>
+      /// \@\<PARTITION\>\@\<NAMESPACE\>/\<TOPIC\>
       ///
-      /// The _partition output argument will be set to <PARTITION>, and the
-      /// _namespaceAndTopic output argument will be set to <NAMESPACE>/<TOPIC>.
+      /// The _partition output argument will be set to \<PARTITION\>, and the
+      /// _namespaceAndTopic output argument will be set to
+      /// \<NAMESPACE\>/\<TOPIC\>.
       ///
       /// \param[in] _fullyQualifiedName The fully qualified topic name.
       /// \param[out] _partition The partition component of the fully qualified

--- a/log/include/ignition/transport/log/MsgIter.hh
+++ b/log/include/ignition/transport/log/MsgIter.hh
@@ -43,11 +43,6 @@ namespace ignition
         /// \brief Default constructor
         public: MsgIter();
 
-        /// \brief Copy Constructor
-        /// \param[in] _orig the instance being copied
-        // TODO(anyone)
-        // public: MsgIter(const MsgIter &_orig);
-
         /// \brief Move Constructor
         /// \param[in] _orig the instance being copied
         public: MsgIter(MsgIter &&_orig);  // NOLINT
@@ -63,11 +58,6 @@ namespace ignition
         /// \brief Prefix increment
         /// \return a reference to this instance
         public: MsgIter &operator++();
-
-        /// \brief Postfix increment
-        /// \return a reference to a copy of this iterator before incrementing
-        // TODO(anyone)
-        // public: MsgIter operator++(int);
 
         /// \brief Equality operator
         /// \param[in] _other the iterator this is being compared to

--- a/log/include/ignition/transport/log/Playback.hh
+++ b/log/include/ignition/transport/log/Playback.hh
@@ -48,6 +48,7 @@ namespace ignition
       {
         /// \brief Constructor
         /// \param[in] _file path to log file
+        /// \param[in] _nodeOptions Options for creating a node.
         public: explicit Playback(const std::string &_file,
                                const NodeOptions &_nodeOptions = NodeOptions());
 

--- a/log/include/ignition/transport/log/QueryOptions.hh
+++ b/log/include/ignition/transport/log/QueryOptions.hh
@@ -70,7 +70,7 @@ namespace ignition
         /// the queries to be ordered by the time the messages were received by
         /// the logger. It will also end the statement with a semicolon.
         ///
-        /// \return \code{" ORDER BY messages.time_recv;"}
+        /// \return \code{" ORDER BY messages.time_recv;"}\endcode
         public: static SqlStatement StandardMessageQueryClose();
 
         /// \brief Virtual destructor
@@ -211,7 +211,7 @@ namespace ignition
         /// \brief Query for topics that match a pattern, over a specified time
         /// range (by default, all time).
         /// \param[in] _pattern The initial pattern that this option should use
-        /// \paramp[in] _timeRange The initial range of time for this option
+        /// \param[in] _timeRange The initial range of time for this option
         public: TopicPattern(
           const std::regex &_pattern,
           const QualifiedTimeRange &_timeRange = QualifiedTimeRange::AllTime());

--- a/log/include/ignition/transport/log/SqlStatement.hh
+++ b/log/include/ignition/transport/log/SqlStatement.hh
@@ -74,7 +74,7 @@ namespace ignition
         /// \sa Set(const std::string &)
         /// \brief Construct string parameter
         /// \param[in] _string a string
-        public: explicit SqlParameter(const std::string &_text);
+        public: explicit SqlParameter(const std::string &_string);
 
         /// \brief Copy constructor
         /// \param[in] _other Another SqlParameter

--- a/src/Publisher_TEST.cc
+++ b/src/Publisher_TEST.cc
@@ -272,6 +272,12 @@ TEST(PublisherTest, ServicePublisher)
   EXPECT_TRUE(pub1 == pub2);
   EXPECT_FALSE(pub1 != pub2);
 
+  ServicePublisher pub3;
+  pub3 = pub1;
+
+  EXPECT_TRUE(pub1 == pub3);
+  EXPECT_FALSE(pub1 != pub3);
+
   // Modify the publisher's member variables.
   pub1.SetTopic(g_newTopic);
   pub1.SetAddr(g_newAddr);

--- a/tutorials/03_nodesAndTopics.md
+++ b/tutorials/03_nodesAndTopics.md
@@ -31,7 +31,7 @@ subscribe to the same topic and will receive the messages containing the image.
 A node could also offer an echo service in the topic `/echo`. Any node
 interested in this service will request a service call on topic `/echo`. The
 service call will accept arguments and will return a result. In our echo
-service example (\ref services), the result will be similar 
+service example (\ref services), the result will be similar
 to the input parameter passed to the service.
 
 There are some rules to follow when selecting a topic name. It should be any
@@ -51,7 +51,7 @@ The following symbols are not allowed as part of the topic name: `@`, `:=`, `~`.
 | //image     | Invalid  | Contains two consecutive `//` |
 | /           | Invalid  | `/` topic is not allowed      |
 | ~myTopic    | Invalid  | Symbol `~` not allowed        |
-| @myTopic    | Invalid  | Symbol `@` not allowed        |
+| \@myTopic   | Invalid  | Symbol `@` not allowed        |
 | myTopic:=   | Invalid  | Symbol `:=` not allowed       |
 
 ## Topic scope

--- a/tutorials/21_contribute.md
+++ b/tutorials/21_contribute.md
@@ -1,1 +1,3 @@
+\page contribute Contribute
+
 See [Ignition's contribution guide](https://ignitionrobotics.org/docs/all/contributing).


### PR DESCRIPTION
# 🎉 New feature

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->

Add `cppcheck`, `cpplint` and doxygen checks.

## Test it
<!--Explain how reviewers can test this new feature manually.-->

Focal CI on GitHub actions should return green.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
