### PR TITLE
Use exec instead of popen to run CLI11 based binaries

### DIFF
--- a/src/cmd/cmdtransport.rb.in
+++ b/src/cmd/cmdtransport.rb.in
@@ -51,16 +51,6 @@ class Cmd
     end
 
     # Drop command from list of arguments
-    Open3.popen2e(exe_name, *args[1..-1]) do |_in, out_err, wait_thr|
-      begin
-        out_err.each do |line|
-          print line
-        end
-        exit(wait_thr.value.exitstatus)
-      rescue Interrupt => e
-        print e.message
-        exit(-1)
-      end
-    end
+    exec(exe_name, *args[1..-1])
   end
 end


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
See https://github.com/ignitionrobotics/ign-launch/pull/151

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

